### PR TITLE
Allow metadata to be specified inline rather than as file

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ config :samly, Samly.Provider,
 | `id` | _(mandatory)_ This will be the idp_id in the URLs |
 | `sp_id` | _(mandatory)_ The service provider definition to be used with this Identity Provider definition |
 | `base_url` | _(optional)_ If missing `Samly` will use the current URL to derive this. It is better to define this in production deployment. |
-| `metadata_file` | _(mandatory)_ Path to the IdP metadata XML file obtained from the Identity Provider. |
+| `metadata_file` | _(mandatory if `metadata` is not set)_ Path to the IdP metadata XML file obtained from the Identity Provider. This will be ignored if `metadata` is non-nil. |
+| `metadata` | _(mandatory if `metadata_file` is not set))_ String containing IdP metadata XML obtained from the Identity Provider. |
 | `pre_session_create_pipeline` | _(optional)_ Check the customization section. |
 | `use_redirect_for_req` | _(optional)_ Default is `false`. When this is `false`, `Samly` will POST to the IdP SAML endpoints. |
 | `sign_requests`, `sign_metadata` | _(optional)_ Default is `true`. |

--- a/test/samly_idp_data_test.exs
+++ b/test/samly_idp_data_test.exs
@@ -44,6 +44,13 @@ defmodule SamlyIdpDataTest do
     metadata_file: "test/data/idp_metadata.xml"
   }
 
+  @idp_config3 %{
+    id: "idp3",
+    sp_id: "sp2",
+    base_url: "http://samly.howto:4003/sso",
+    metadata: File.read!("test/data/idp_metadata.xml")
+  }
+
   setup context do
     sp_data1 = SpData.load_provider(@sp_config1)
     sp_data2 = SpData.load_provider(@sp_config2)
@@ -189,6 +196,13 @@ defmodule SamlyIdpDataTest do
 
   test "sp entity_id test-1", %{sps: sps} do
     %IdpData{} = idp_data = IdpData.load_provider(@idp_config2, sps)
+    assert idp_data.valid?
+    Esaml.esaml_sp(entity_id: entity_id) = idp_data.esaml_sp_rec
+    assert entity_id == :undefined
+  end
+
+  test "metadata supplied inline rather than as file", %{sps: sps} do
+    %IdpData{} = idp_data = IdpData.load_provider(@idp_config3, sps)
     assert idp_data.valid?
     Esaml.esaml_sp(entity_id: entity_id) = idp_data.esaml_sp_rec
     assert entity_id == :undefined


### PR DESCRIPTION
This change allows metadata to be specified directly in the IdP config rather than requiring a file. This is handy if you're trying to, say, dynamically configure IdPs from a database.