### PR TITLE
Added Google to list of IdPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This has been used in the wild with the following Identity Providers:
 + Nexus GO
 + Shibboleth
 + SimpleSAMLphp
++ Google
 
 This library uses Erlang [`esaml`](https://github.com/dropbox/esaml) to provide plug enabled routes.
 


### PR DESCRIPTION
I've successfully integrated with Google's SAML IdP using Samly, so I added it to the list