### PR TITLE
Config refresh

### DIFF
--- a/lib/samly/provider.ex
+++ b/lib/samly/provider.ex
@@ -60,6 +60,10 @@ defmodule Samly.Provider do
     refresh_providers()
   end
 
+  @doc """
+  Refresh the provider configuration, allowing runtime-configuration to be applied after
+  application start.
+  """
   def refresh_providers do
     opts = Application.get_env(:samly, Samly.Provider, [])
 

--- a/lib/samly/provider.ex
+++ b/lib/samly/provider.ex
@@ -57,6 +57,12 @@ defmodule Samly.Provider do
 
     Application.put_env(:samly, :idp_id_from, idp_id_from)
 
+    refresh_providers()
+  end
+
+  def refresh_providers do
+    opts = Application.get_env(:samly, Samly.Provider, [])
+
     service_providers = Samly.SpData.load_providers(opts[:service_providers] || [])
 
     identity_providers =

--- a/test/samly_config_test.exs
+++ b/test/samly_config_test.exs
@@ -1,0 +1,37 @@
+defmodule SamlyConfigTest do
+  use ExUnit.Case
+
+  alias Samly.Provider
+
+  @sp_config %{
+    id: "sp1",
+    entity_id: "urn:test:sp1",
+    certfile: "test/data/test.crt",
+    keyfile: "test/data/test.pem"
+  }
+
+  @idp_config %{
+    id: "idp1",
+    sp_id: "sp1",
+    base_url: "http://samly.howto:4003/sso",
+    metadata_file: "test/data/idp_metadata.xml"
+  }
+
+  test "refresh_providers" do
+    Application.put_env(:samly, Provider,
+      service_providers: [@sp_config],
+      identity_providers: [@idp_config]
+    )
+
+    assert Application.get_env(:samly, :service_providers) == nil
+    assert Application.get_env(:samly, :identity_providers) == nil
+
+    Provider.refresh_providers()
+
+    sps = Application.get_env(:samly, :service_providers)
+    assert sps == %{"sp1" => Samly.SpData.load_provider(@sp_config)}
+
+    assert Application.get_env(:samly, :identity_providers) ==
+             %{"idp1" => Samly.IdpData.load_provider(@idp_config, sps)}
+  end
+end


### PR DESCRIPTION
This is a pretty simple change that allows a client to refresh the runtime provider config without restarting the app. This is useful if you have a bunch of providers that you want to provision at runtime from a database.