### PR TITLE
Fix Esaml ETS initialisation issue

### DIFF
--- a/lib/samly/provider.ex
+++ b/lib/samly/provider.ex
@@ -56,6 +56,7 @@ defmodule Samly.Provider do
       end
 
     Application.put_env(:samly, :idp_id_from, idp_id_from)
+    :esaml_util.start_ets()
 
     refresh_providers()
   end


### PR DESCRIPTION
Attempt to use Samly in umbrella app leading to error in config initialization:
```
[error] [Samly] Failed load SP certfile ["apps/itulink_web/priv/cert/selfsigned.pem"]: %{certfile: "apps/itulink_web/priv/cert/selfsigned.pem", id: "link-itu-edu", keyfile: "apps/itulink_web/priv/cert/selfsigned_key.pem"} %ArgumentError{message: "errors were found at the given arguments:\n\n  * 1st argument: the table identifier does not refer to an existing ETS table\n"}     lib/samly/sp_data.ex:67: Samly.SpData.load_provider/1
    (elixir 1.13.4) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    lib/samly/sp_data.ex:47: Samly.SpData.load_providers/1
    lib/samly/provider.ex:70: Samly.Provider.refresh_providers/0
    (stdlib 3.17.1) gen_server.erl:423: :gen_server.init_it/2
    (stdlib 3.17.1) gen_server.erl:390: :gen_server.init_it/6
    (stdlib 3.17.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```
It can be mitigated with this change, which is not affecting anything if ETS is already running for Esaml.