### PR TITLE
Allow for setting a custom string assertion key in pipeline

### DIFF
--- a/lib/samly.ex
+++ b/lib/samly.ex
@@ -28,6 +28,9 @@ defmodule Samly do
       {_idp_id, _nameid} = assertion_key ->
         State.get_assertion(conn, assertion_key)
 
+      assertion_key when is_binary(assertion_key) ->
+        State.get_assertion(conn, assertion_key)
+
       _ ->
         nil
     end

--- a/lib/samly/sp_handler.ex
+++ b/lib/samly/sp_handler.ex
@@ -50,7 +50,7 @@ defmodule Samly.SPHandler do
 
       conn
       |> configure_session(renew: true)
-      |> put_session("samly_assertion_key", assertion_key)
+      |> put_session_new("samly_assertion_key", assertion_key)
       |> redirect(302, target_url)
     else
       {:halted, conn} -> conn
@@ -117,6 +117,13 @@ defmodule Samly.SPHandler do
 
   defp auth_target_url(conn, _assertion, _relay_state) do
     get_session(conn, "target_url") || "/"
+  end
+
+  defp put_session_new(conn, key, value) do
+    case get_session(conn, key) do
+      nil -> put_session(conn, key, value)
+      _ -> conn
+    end
   end
 
   def handle_logout_response(conn) do


### PR DESCRIPTION
My company, dscout, is looking to use Samly. 

Currently we share our session data between a Phoenix application and a legacy Rails application, so our `Plug.Session` requires that we specify a serializer for valid JSON (we're using Jason). 

We ran into a few issues setting this up since tuples and structs aren't valid JSON. We solved most of the issue using the custom state configuration and converting structs to maps, but ran into an issue with the tuple assertion key. 

This change allows for setting that key during the custom pipeline step and updates `Samly.SPHandler` to only add that to the session is none already exists. 