### PR TITLE
fix: remove double url encoding

### DIFF
--- a/lib/samly/router_util.ex
+++ b/lib/samly/router_util.ex
@@ -100,7 +100,7 @@ defmodule Samly.RouterUtil do
 
   def redirect(conn, status_code, dest) do
     conn
-    |> Conn.put_resp_header("location", URI.encode(dest))
+    |> Conn.put_resp_header("location", dest)
     |> Conn.send_resp(status_code, "")
     |> Conn.halt()
   end


### PR DESCRIPTION
# Describe the bug:
In the case where `use_redirect_for_req` is set to `true` (it defaults to false), Samly is URL encoding the query string twice.

# How to reproduce:
Consider the following iex snippet that aims to create reproduce the relevant section in `Samly.AuthHandler.send_signin_req` (I'm just using phoenix to create a test plug conn here):
```
Mix.install([{:phoenix, "~> 1.7.7"}, {:samly, "~> 1.3"}])
conn = Phoenix.ConnTest.build_conn()
idp = %Samly.IdpData{id: "some_id"}
sp = Samly.RouterUtil.ensure_sp_uris_set(idp.esaml_sp_rec, conn)
{idp_signin_url, req_xml_frag} = Samly.Helper.gen_idp_signin_req(sp, idp.esaml_idp_rec, idp.nameid_format)
Samly.RouterUtil.send_saml_request(conn, idp_signin_url, true, req_xml_frag, "12n2ceviquxiNUWJFagm1WvQfRLe7X5Z")
```

The result produces the following query string: 
```
?SAMLEncoding=urn%253Aoasis%253Anames%253Atc%253ASAML%253A2.0%253Abindings%253AURL-Encoding%253ADEFLATE&SAMLRequest=fZBPT8MwDMW%25252FSpR7R5r%25252BGbXaToUdmDREtRYO3EIXQaTWGXE68fEpHZOYkHa0%25252FZ7988tXX0PPjtqRsVjwcCH4qsxJDf0BqtF%25252F4E5%25252Fjpo8m2RIMA8KPjoEq8gQoBo0ge%25252BgqR63IBcCDs5629me%25252F7Fcdygi7fx0n7MN0ag3SF6hL7gUMgpCEYi4DWOIbiGWr5y9nGEnL2frCc6g8nOHs%25252Bq8694ijYN2jXZH0%25252Bnn3fZnXP%25252FC3RncG3y%25252FzvV2EhE8tG0d1E9NOwGuC272YZqlcSQiKZfZMpUyTpJQRknGT9HB%25252FIYr85v%25252F1WWs5Tc%25253D&RelayState=98374897slksdf
```

You can reproduce the segment made by esaml by calling:
```
:esaml_binding.encode_http_redirect(idp_signin_url, req_xml_frag, :undefined, "12n2ceviquxiNUWJFagm1WvQfRLe7X5Z")
```
Resulting in:
```
"?SAMLEncoding=urn%3Aoasis%3Anames%3Atc%3ASAML%3A2.0%3Abindings%3AURL-Encoding%3ADEFLATE&SAMLRequest=fZBBT8MwDIX%252FSuT7RtKWolptp8IOTBqiWgsHbqGLIFLrjDid%252BPmUjkkgpB1tv2d%252Ffvnqc%252BjF0Xi2jgpQSwmrMmc99AesxvBOO%252FMxGg5ikhHjPChg9IROs2UkPRjG0GFTPWwxWko8eBdc53r4Zbns0MzGh%252Bk%252BiA3zaDbEQVMoIJJRvFByIZNWJZhIjLMXEM9n2MkLYj3BWdJh7oCozrvuHPE4GN8Yf7Sdedptv8f1D9ytpb2lt8tcrycR433b1ov6sWknwHUBdq%252FSLE1imcSZSm%252FiVF5nSqlMSThFh%252FMbvsyv%252Fld%252FYy2%252FAA%253D%253D&RelayState=12n2ceviquxiNUWJFagm1WvQfRLe7X5Z"
```

Which shows that the SAMLEncoding url parameter is already correctly URL encoded. Seeing that that field is hardcoded into esaml (the deflate field) and not controlled by any supplied input, I'm sure the underlying `uri_string:compose_query` is sufficient to URL encode the query parameters.

I can reproduce this bug with a test SAML IdP setup in docker, and in a pre-production environment with a Microsoft AD setup, but the above snippets are just quicker to get to the same point.

There is still the issue that esaml also double encodes the SAMLRequest. Will link the PR to address that on this issue for reference when I've submitted that patch.