### PR TITLE
Add debug mode that displays the full raw response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # CHANGELOG
 
-### v1.3.0
+### v1.4.0
 +   remove uri double encoding thanks to @DiaanEngelbrecht
 +   fix esaml initialization thanks to @bopm
-+   check and enforce session expiration thanks to @idyll
++   check and enforce session expiration (CVE-2024-25718) thanks to @idyll
 
 ### v1.3.0
 +   Added dialyzer checks

--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -23,6 +23,7 @@ defmodule Samly.IdpData do
             signed_envelopes_in_resp: true,
             allow_idp_initiated_flow: false,
             allowed_target_urls: [],
+            debug_mode: false,
             entity_id: "",
             signed_requests: "",
             certs: [],
@@ -50,6 +51,7 @@ defmodule Samly.IdpData do
           signed_envelopes_in_resp: boolean(),
           allow_idp_initiated_flow: boolean(),
           allowed_target_urls: nil | [binary()],
+          debug_mode: boolean(),
           entity_id: binary(),
           signed_requests: binary(),
           certs: certs(),
@@ -120,6 +122,7 @@ defmodule Samly.IdpData do
     |> set_boolean_attr(opts_map, :signed_assertion_in_resp)
     |> set_boolean_attr(opts_map, :signed_envelopes_in_resp)
     |> set_boolean_attr(opts_map, :allow_idp_initiated_flow)
+    |> set_boolean_attr(opts_map, :debug_mode)
   end
 
   @spec load_metadata(%IdpData{}) :: %IdpData{}

--- a/lib/samly/sp_handler.ex
+++ b/lib/samly/sp_handler.ex
@@ -59,7 +59,7 @@ defmodule Samly.SPHandler do
           %IdpData{debug_mode: true} ->
             conn
             |> put_resp_header("content-type", "text/html")
-            |> send_resp(403, "<html><body><h1>access_denied<h1><p><b>Error:</b><br /><code>#{inspect(reason)}</code></p><p><b>Raw Response:</b><br /><code>#{inspect(saml_response)}</code></p></body></html")
+            |> send_resp(403, "<html><body><div><h1>access_denied</h1><p><b>Error:</b><br /><pre><code>#{inspect(reason)}</code></pre></p><p><b>Raw Response:</b><br /><pre><code>#{saml_response}</code></pre></p></div></body></html")
           _ ->
             conn |> send_resp(403, "access_denied #{inspect(reason)}")
         end

--- a/lib/samly/sp_handler.ex
+++ b/lib/samly/sp_handler.ex
@@ -54,7 +54,15 @@ defmodule Samly.SPHandler do
       |> redirect(302, target_url)
     else
       {:halted, conn} -> conn
-      {:error, reason} -> conn |> send_resp(403, "access_denied #{inspect(reason)}")
+      {:error, reason} ->
+        case idp do
+          %IdpData{debug_mode: true} ->
+            conn
+            |> put_resp_header("content-type", "text/html")
+            |> send_resp(403, "<html><body><h1>access_denied<h1><p><b>Error:</b><br /><code>#{inspect(reason)}</code></p><p><b>Raw Response:</b><br /><code>#{inspect(saml_response)}</code></p></body></html")
+          _ ->
+            conn |> send_resp(403, "access_denied #{inspect(reason)}")
+        end
       _ -> conn |> send_resp(403, "access_denied")
     end
 


### PR DESCRIPTION
This is that start of some changes that I am working on to improve error handling during the SAML setup process.

Recently I had to connect to an IdP that by default excludes certificate information in the SAML response. (Specifically the `KeyInfo` element.) 

esaml expects the presence of the KeyInfo element and computes a signature of the embedded cert to ensure it matches the IdP then uses the embedded cert directly to verify any signatures. I suspect this is necessary in cases where there could be multiple signing certs but it means that the KeyInfo element must be included.

In order to troubleshoot situations like this I've added a debug option where the failure page can now include the SAML response. `debug_mode: true`. The default is set to false.

I think that it would make a lot of sense to explore better failure and error pages, but I know that we block inline style in our CSP so I imagine it will be difficult to get this right. This is a good start nonetheless.