### PR TITLE
Fix record types in IdpData

### DIFF
--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -61,8 +61,8 @@ defmodule Samly.IdpData do
           slo_post_url: url(),
           nameid_format: nameid_format(),
           fingerprints: [binary()],
-          esaml_idp_rec: :esaml_idp_metadata,
-          esaml_sp_rec: :esaml_sp,
+          esaml_idp_rec: :esaml.idp_metadata(),
+          esaml_sp_rec: :esaml.sp(),
           valid?: boolean()
         }
 


### PR DESCRIPTION
Hello there 👋🏼 

Previously, dialyzer objected to the use of data from these two fields in a call to update the record (for example, `Esaml.esaml_sp(sp, ...)`. This wasn't obvious because callers tend to pull `%IdpData{}` structs out of `conn.private`, without any assertion that the data should conform to `IdpData.t()`. Warnings would only appear if someone attempted to modify data straight out of `Helper.get_idp/1` or something similar.

Luckily, `:esaml` provides types for these records.