### PR TITLE
Allow IDPs to be set dynamically by other plugs

### DIFF
--- a/lib/samly/router_util.ex
+++ b/lib/samly/router_util.ex
@@ -8,7 +8,9 @@ defmodule Samly.RouterUtil do
 
   @subdomain_re ~r/^(?<subdomain>([^.]+))?\./
 
-  def check_idp_id(conn, _opts) do
+  def check_idp_id(%Conn{private: %{samly_idp: %IdpData{}}} = conn, _opts), do: conn
+
+  def check_idp_id(conn, _opts), do: conn
     idp_id_from = Application.get_env(:samly, :idp_id_from)
 
     idp_id =


### PR DESCRIPTION
I am working on an application that may have many IDP configurations, and they may need to be loaded dynamically.  I believe this small modification would enable me to set the IDP configuration dynamically via a plug that runs earlier than Samly.