### PR TITLE
Customizing Relay State

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,25 @@ config :samly, Samly.State,
 |:------------|:-----------|
 | `opts` | _(optional)_ The `:key` is the name of the session key where assertion is stored. Default is `:samly_assertion`. |
 
+#### Relay State customization
+
+By default, Samly sets the relay state to a random string.
+However, you can set any specific value to the relay state.
+
+Set a fixed string as the relay state using the following:
+```elixir
+config :samly, Samly.State,
+  relay_state: "any-specific-string"
+```
+
+Set the relay state to the result of an annonymous function using the follows:
+```elixir
+config :samly, Samly.State,
+  relay_state: fn conn ->
+    "#{conn.scheme}://#{conn.host}#{conn.request_path}"
+   end
+```
+
 ## SAML Assertion
 
 Once authentication is completed successfully, IdP sends a "consume" SAML

--- a/lib/samly/auth_handler.ex
+++ b/lib/samly/auth_handler.ex
@@ -67,7 +67,7 @@ defmodule Samly.AuthHandler do
         conn |> redirect(302, target_url)
 
       _ ->
-        relay_state = State.gen_id()
+        relay_state = State.create_relay_state(conn)
 
         {idp_signin_url, req_xml_frag} =
           Helper.gen_idp_signin_req(sp, idp_rec, Map.get(idp, :nameid_format))
@@ -109,7 +109,7 @@ defmodule Samly.AuthHandler do
           Helper.gen_idp_signout_req(sp, idp_rec, subject_rec, session_index)
 
         conn = State.delete_assertion(conn, assertion_key)
-        relay_state = State.gen_id()
+        relay_state = State.create_relay_state(conn)
 
         conn
         |> put_session("target_url", target_url)

--- a/lib/samly/provider.ex
+++ b/lib/samly/provider.ex
@@ -34,7 +34,8 @@ defmodule Samly.Provider do
     store_env = Application.get_env(:samly, Samly.State, [])
     store_provider = store_env[:store] || Samly.State.ETS
     store_opts = store_env[:opts] || []
-    State.init(store_provider, store_opts)
+    relay_state = store_env[:relay_state] || (&Samly.State.gen_id/1)
+    State.init(store_provider, store_opts, relay_state)
 
     opts = Application.get_env(:samly, Samly.Provider, [])
 

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -3,11 +3,14 @@ defmodule Samly.State do
 
   @state_store :state_store
 
-  def init(store_provider), do: init(store_provider, [])
-
-  def init(store_provider, opts) do
+  def init(store_provider, opts \\ [], relay_state \\ &gen_id/1) do
     opts = store_provider.init(opts)
-    Application.put_env(:samly, @state_store, %{provider: store_provider, opts: opts})
+
+    Application.put_env(:samly, @state_store, %{
+      provider: store_provider,
+      opts: opts,
+      relay_state: relay_state
+    })
   end
 
   def get_assertion(conn, assertion_key) do

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -25,7 +25,8 @@ defmodule Samly.State do
     store_provider.delete_assertion(conn, assertion_key, opts)
   end
 
-  def gen_id() do
+  @spec gen_id :: String.t()
+  def gen_id do
     24 |> :crypto.strong_rand_bytes() |> Base.url_encode64()
   end
 end

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -28,6 +28,20 @@ defmodule Samly.State do
     store_provider.delete_assertion(conn, assertion_key, opts)
   end
 
+  @spec create_relay_state(Plug.Conn.t()) :: String.t()
+  def create_relay_state(conn) do
+    case Application.get_env(:samly, @state_store).relay_state do
+      relay_state when is_function(relay_state, 1) ->
+        relay_state.(conn)
+
+      relay_state when is_binary(relay_state) ->
+        relay_state
+
+      relay_state ->
+        raise "Invalid relay_state: expected a function of arity 1 or a string, got #{inspect(relay_state)}"
+    end
+  end
+
   @spec gen_id(Plug.Conn.t()) :: String.t()
   def gen_id(_conn) do
     gen_id()

--- a/lib/samly/state.ex
+++ b/lib/samly/state.ex
@@ -25,6 +25,11 @@ defmodule Samly.State do
     store_provider.delete_assertion(conn, assertion_key, opts)
   end
 
+  @spec gen_id(Plug.Conn.t()) :: String.t()
+  def gen_id(_conn) do
+    gen_id()
+  end
+
   @spec gen_id :: String.t()
   def gen_id do
     24 |> :crypto.strong_rand_bytes() |> Base.url_encode64()


### PR DESCRIPTION
Currently, Samly only sets random relay state value.
However, our product requires setting a specific value, such as a URL, as the relay state.

This Pull Request adds support for setting a specific relay state value, through configuration setting.
