### PR TITLE
Remove elixir 1 9 deprecations

### DIFF
--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -112,7 +112,7 @@ defmodule Samly.IdpData do
   @spec save_idp_config(%IdpData{}, map()) :: %IdpData{}
   defp save_idp_config(idp_data, %{id: id, sp_id: sp_id} = opts_map)
        when is_binary(id) and is_binary(sp_id) do
-    %IdpData{idp_data | id: id, sp_id: sp_id, base_url: Map.get(opts_map, :base_url)}
+    %{idp_data | id: id, sp_id: sp_id, base_url: Map.get(opts_map, :base_url)}
     |> set_metadata(opts_map)
     |> set_pipeline(opts_map)
     |> set_allowed_target_urls(opts_map)
@@ -156,9 +156,9 @@ defmodule Samly.IdpData do
   defp update_esaml_recs(idp_data, service_providers, opts_map) do
     case Map.get(service_providers, idp_data.sp_id) do
       %SpData{} = sp ->
-        idp_data = %IdpData{idp_data | esaml_idp_rec: to_esaml_idp_metadata(idp_data, opts_map)}
-        idp_data = %IdpData{idp_data | esaml_sp_rec: get_esaml_sp(sp, idp_data)}
-        %IdpData{idp_data | valid?: cert_config_ok?(idp_data, sp)}
+        idp_data = %{idp_data | esaml_idp_rec: to_esaml_idp_metadata(idp_data, opts_map)}
+        idp_data = %{idp_data | esaml_sp_rec: get_esaml_sp(sp, idp_data)}
+        %{idp_data | valid?: cert_config_ok?(idp_data, sp)}
 
       _ ->
         Logger.error("[Samly] Unknown/invalid sp_id: #{idp_data.sp_id}")
@@ -271,7 +271,7 @@ defmodule Samly.IdpData do
     md_xml = SweetXml.parse(metadata_xml, xml_opts)
     signing_certs = get_signing_certs(md_xml)
 
-    %IdpData{
+    %{
       idp_data
       | entity_id: get_entity_id(md_xml),
         signed_requests: get_req_signed(md_xml),

--- a/lib/samly/sp_handler.ex
+++ b/lib/samly/sp_handler.ex
@@ -36,12 +36,12 @@ defmodule Samly.SPHandler do
 
     with {:ok, assertion} <- Helper.decode_idp_auth_resp(sp, saml_encoding, saml_response),
          :ok <- validate_authresp(conn, assertion, relay_state),
-         assertion = %Assertion{assertion | idp_id: idp_id},
+         assertion = %{assertion | idp_id: idp_id},
          conn = conn |> put_private(:samly_assertion, assertion),
          {:halted, %Conn{halted: false} = conn} <- {:halted, pipethrough(conn, pipeline)} do
       updated_assertion = conn.private[:samly_assertion]
       computed = updated_assertion.computed
-      assertion = %Assertion{assertion | computed: computed, idp_id: idp_id}
+      assertion = %{assertion | computed: computed, idp_id: idp_id}
 
       nameid = assertion.subject.name
       assertion_key = {idp_id, nameid}

--- a/lib/samly/sp_handler.ex
+++ b/lib/samly/sp_handler.ex
@@ -53,17 +53,25 @@ defmodule Samly.SPHandler do
       |> put_session("samly_assertion_key", assertion_key)
       |> redirect(302, target_url)
     else
-      {:halted, conn} -> conn
+      {:halted, conn} ->
+        conn
+
       {:error, reason} ->
         case idp do
           %IdpData{debug_mode: true} ->
             conn
             |> put_resp_header("content-type", "text/html")
-            |> send_resp(403, "<html><body><div><h1>access_denied</h1><p><b>Error:</b><br /><pre><code>#{inspect(reason)}</code></pre></p><p><b>Raw Response:</b><br /><pre><code>#{saml_response}</code></pre></p></div></body></html")
+            |> send_resp(
+              403,
+              "<html><body><div><h1>access_denied</h1><p><b>Error:</b><br /><pre><code>#{inspect(reason)}</code></pre></p><p><b>Raw Response:</b><br /><pre><code>#{saml_response}</code></pre></p></div></body></html"
+            )
+
           _ ->
             conn |> send_resp(403, "access_denied #{inspect(reason)}")
         end
-      _ -> conn |> send_resp(403, "access_denied")
+
+      _ ->
+        conn |> send_resp(403, "access_denied")
     end
 
     # rescue


### PR DESCRIPTION
With elixir v1.9 there are warnings when updating structs using the struct name. e.g.

```elixir
%User{user | name: "John Doe"} # deprecated in elixir v1.9
```

vs

```elixir
%{user | name: "John Doe"}
```

This change is backward compatible with old elixir versions.

**After**

```sh
$ mix compile --force
Compiling 20 files (.ex)
Generated samly app
```

**Before**

```sh
$ mix compile --force

Compiling 20 files (.ex)
    warning: a struct for Samly.Assertion is expected on struct update:

        %Samly.Assertion{assertion | idp_id: idp_id}

    but got type:

        dynamic()

    where "assertion" was given the type:

        # type: dynamic()
        # from: lib/samly/sp_handler.ex:37:27
        {:ok, assertion} <- Samly.Helper.decode_idp_auth_resp(sp, saml_encoding, saml_response)

    when defining the variable "assertion", you must also pattern match on "%Samly.Assertion{}".

    hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

        user = some_function()
        %User{user | name: "John Doe"}

    it is enough to write:

        %User{} = user = some_function()
        %{user | name: "John Doe"}

    typing violation found at:
    │
 39 │          assertion = %Assertion{assertion | idp_id: idp_id},
    │                      ~
    │
    └─ lib/samly/sp_handler.ex:39:22: Samly.SPHandler.consume_signin_response/1

     warning: a struct for Samly.IdpData is expected on struct update:

         %Samly.IdpData{idp_data | id: id, sp_id: sp_id, base_url: Map.get(opts_map, :base_url)}

     but got type:

         dynamic()

     where "idp_data" was given the type:

         # type: dynamic()
         # from: lib/samly/idp_data.ex:113:24
         idp_data

     when defining the variable "idp_data", you must also pattern match on "%Samly.IdpData{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 115 │     %IdpData{idp_data | id: id, sp_id: sp_id, base_url: Map.get(opts_map, :base_url)}
     │     ~
     │
     └─ lib/samly/idp_data.ex:115:5: Samly.IdpData.save_idp_config/2

     warning: a struct for Samly.IdpData is expected on struct update:

         %Samly.IdpData{idp_data | esaml_idp_rec: to_esaml_idp_metadata(idp_data, opts_map)}

     but got type:

         dynamic()

     where "idp_data" was given the type:

         # type: dynamic()
         # from: lib/samly/idp_data.ex:156:26
         idp_data

     when defining the variable "idp_data", you must also pattern match on "%Samly.IdpData{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 159 │         idp_data = %IdpData{idp_data | esaml_idp_rec: to_esaml_idp_metadata(idp_data, opts_map)}
     │                    ~
     │
     └─ lib/samly/idp_data.ex:159:20: Samly.IdpData.update_esaml_recs/3

     warning: a struct for Samly.IdpData is expected on struct update:

         %Samly.IdpData{
           idp_data
           | entity_id: get_entity_id(md_xml),
             signed_requests: get_req_signed(md_xml),
             certs: signing_certs,
             fingerprints: idp_cert_fingerprints(signing_certs),
             sso_redirect_url: get_sso_redirect_url(md_xml),
             sso_post_url: get_sso_post_url(md_xml),
             slo_redirect_url: get_slo_redirect_url(md_xml),
             slo_post_url: get_slo_post_url(md_xml),
             nameid_format: get_nameid_format(md_xml)
         }

     but got type:

         dynamic()

     where "idp_data" was given the type:

         # type: dynamic()
         # from: lib/samly/idp_data.ex:263:31
         idp_data

     when defining the variable "idp_data", you must also pattern match on "%Samly.IdpData{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 274 │     %IdpData{
     │     ~
     │
     └─ lib/samly/idp_data.ex:274:5: Samly.IdpData.from_xml/2

Generated samly app
```